### PR TITLE
Don't add RSVP and Chalk to project devDependencies

### DIFF
--- a/blueprints/ember-cli-jsdoc/index.js
+++ b/blueprints/ember-cli-jsdoc/index.js
@@ -1,3 +1,6 @@
+var chalk = require( 'chalk' );
+var fs = require( 'fs' );
+
 module.exports = {
     normalizeEntityName: function() {},
 
@@ -37,19 +40,6 @@ module.exports = {
             }
         }
 
-        /**
-         * Chalk library
-         *
-         * @type {Object}
-         */
-        var chalk = require( 'chalk' );
-
-        /**
-         * fs library
-         *
-         * @type {Object}
-         */
-        var fs = require( 'fs' );
 
         /**
          * Package info
@@ -188,11 +178,9 @@ module.exports = {
 
         // NPM dependency
         return this.addPackagesToProject([
-            { name: 'chalk', target: '1.1.3' },
             { name: 'ember-cli-doc-server', target: '1.1.0' },
             { name: 'jsdoc', target: '3.4.3' },
-            { name: 'jsdoc-plugins', target: '1.2.2' },
-            { name: 'rsvp', target: '3.0.18' }
+            { name: 'jsdoc-plugins', target: '1.2.2' }
         ]);
 
     }

--- a/lib/commands/ember-cli-jsdoc.js
+++ b/lib/commands/ember-cli-jsdoc.js
@@ -1,13 +1,14 @@
 'use strict';
 
+var exec = require( 'child_process' ).exec;
+var rsvp = require( 'rsvp' );
+var path = require( 'path' );
+var chalk = require( 'chalk' );
+
 module.exports = {
     name: 'ember-cli-jsdoc',
 
     run: function() {
-        var exec = require( 'child_process' ).exec;
-        var rsvp = require( 'rsvp' );
-        var path = require( 'path' );
-        var chalk = require( 'chalk' );
         var cmdPath = ( Number( process.version.match( /^v(\d+)/ )[1] ) >= 5 ) ?
             path.join( 'node_modules', '.bin', 'jsdoc' ) :
             path.join( 'node_modules', 'ember-cli-jsdoc', 'node_modules', '.bin', 'jsdoc' );


### PR DESCRIPTION
It's not necessary for dependencies to be added to a consuming application or addon in order to be used in a given addon. Just need to make sure that the require statements are at the right places.