### PR TITLE
Fix Issue #40 [Unable to parse async functions]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ember-cli-jsdoc Changelog
 
+### 1.6.1
+
+**BUGFIX**
+
+* [#40](https://github.com/softlayer/ember-cli-jsdoc/issues/40) Unable to parse async functions
+* [Update jsdoc version](<!-- https://github.com/softlayer/ember-cli-jsdoc/commit/86f45ebeec6c9e1ea66b5998a76680322184fc38 -->)
+
 ### 1.6.0
 
 **BUGFIX**

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "chalk": "1.1.3",
     "ember-cli-babel": "5.1.7",
-    "jsdoc": "3.4.3",
+    "jsdoc": "3.5.5",
     "jsdoc-plugins": "1.2.2",
     "rsvp": "3.0.18"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-jsdoc",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Generate documentation of your app/addon from your JSDoc comments",
   "scripts": {
     "build": "ember build",


### PR DESCRIPTION
`ember-cli-jsdoc` needs an updated version of `jsdoc` to compile docs for code that uses async/await.